### PR TITLE
Reduce vertical scrolling with long lists of targets

### DIFF
--- a/autograde/templates/results.html
+++ b/autograde/templates/results.html
@@ -33,7 +33,7 @@
                     <td>
                         <b>ID:</b> {{ hash(r.id) }}<br>
                         <b>Label:</b> <i>{{ r.label|e }}</i><br>
-                        <b>Target(s):</b> <code>{{ r.target|join(',') }}</code><br>
+                        <b>Target(s):</b> <code>{{ r.target|join(', ') }}</code><br>
                     </td>
                     <td style="text-align: right; font-size: 1.1em">
                         {% if edit_mode %}


### PR DESCRIPTION
Add a space in between the targets of each unit test to allow for proper word breaking. Should make the overall results page much more readable on smallish screens (<2500 px width, but really depending on the number of targets) if there's long lists of targets.